### PR TITLE
Display/Dump implementation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl<T> Snarc<T> {
     /// Internal cloning function.
     ///
     /// Directly accepts a `Site` instance, creates the correct `Origin` with
-    /// `OriginKind::ClonedFrom`.
+    /// `OriginKind::Cloned`.
     fn clone_at_site(&self, site: Site) -> Snarc<T> {
         let mut map = self.inner.map.lock().unwrap();
         let parent_origin = map
@@ -140,7 +140,7 @@ impl<T> Snarc<T> {
             .expect("Internal consistency error (clone). This should never happen.")
             .clone();
         let new_origin = Origin {
-            kind: OriginKind::ClonedFrom(self.id, Box::new(parent_origin)),
+            kind: OriginKind::Cloned(self.id, Box::new(parent_origin)),
             site,
         };
         let new_id = map.next_id();
@@ -155,7 +155,7 @@ impl<T> Snarc<T> {
     /// Internal downgrade function.
     ///
     /// Directly accepts a `Site` instance, creates the correct `Origin` with
-    /// `OriginKind::DowngradedFrom`.
+    /// `OriginKind::Downgraded`.
     fn downgrade_at_site(this: &Self, site: Site) -> Weak<T> {
         let mut map = this.inner.map.lock().unwrap();
         // No need to `::remove` here because the strong ref will be dropped.
@@ -165,7 +165,7 @@ impl<T> Snarc<T> {
             .expect("Internal consistency error (downgrade). This should never happen.")
             .clone();
         let new_origin = Origin {
-            kind: OriginKind::DowngradedFrom(this.id, Box::new(prev_origin)),
+            kind: OriginKind::Downgraded(this.id, Box::new(prev_origin)),
             site,
         };
         let new_id = map.next_id();
@@ -297,7 +297,7 @@ impl<T> Weak<T> {
     /// Internal upgrade function.
     ///
     /// Directly accepts a `Site` instance, creates the correct `Origin` with
-    /// `OriginKind::UpgradedFrom`.
+    /// `OriginKind::Upgraded`.
     pub fn upgrade_at_site(&self, site: Site) -> Option<Snarc<T>> {
         let id = self.id?;
 
@@ -310,7 +310,7 @@ impl<T> Weak<T> {
                     .expect("Internal consistency error (upgrade)")
                     .clone();
                 let new_origin = Origin {
-                    kind: OriginKind::UpgradedFrom(id, Box::new(prev_origin)),
+                    kind: OriginKind::Upgraded(id, Box::new(prev_origin)),
                     site,
                 };
                 let new_id = map.next_id();
@@ -324,7 +324,7 @@ impl<T> Weak<T> {
     /// Internal cloning function.
     ///
     /// Directly accepts a `Site` instance, creates the correct `Origin` with
-    /// `OriginKind::ClonedFrom`.
+    /// `OriginKind::Cloned`.
     fn clone_at_site(&self, site: Site) -> Weak<T> {
         // We need to create a temporary untracked strong reference here, no way around it.
         //
@@ -348,7 +348,7 @@ impl<T> Weak<T> {
                     .expect("Internal consistency error (weak clone). This should never happen.")
                     .clone();
                 let new_origin = Origin {
-                    kind: OriginKind::ClonedFrom(our_id, Box::new(parent_origin)),
+                    kind: OriginKind::Cloned(our_id, Box::new(parent_origin)),
                     site,
                 };
                 let new_id = map.next_id();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,37 @@ impl<T> Snarc<T> {
     pub fn get_mut(this: &mut Snarc<T>) -> Option<&mut T> {
         Arc::get_mut(&mut this.inner).map(|inner| &mut inner.data)
     }
+
+    /// Returns the origin chain of this reference.
+    ///
+    /// The resulting `Origin` can be printed using `fmt::Display`, see the `tracing` docs for
+    /// details.
+    pub fn origin(this: &Snarc<T>) -> Origin {
+        this.inner
+            .map
+            .lock()
+            .expect("Poisoned strong mapping. This is a bug.")
+            .strongs
+            .get(&this.id)
+            .expect("Internal consisency error (origin). This is a bug.")
+            .clone()
+    }
+
+    /// Returns the origin of the reference and all of its siblings.
+    ///
+    /// Returns a tuple of (strong origins, weak origins), including all live references.
+    pub fn family(this: &Snarc<T>) -> (Vec<Origin>, Vec<Origin>) {
+        let map = this
+            .inner
+            .map
+            .lock()
+            .expect("Poisoned strong mapping. This is a bug.");
+
+        (
+            map.strongs.values().cloned().collect(),
+            map.weaks.values().cloned().collect(),
+        )
+    }
 }
 
 impl<T> Snarc<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,9 @@ impl<T> Snarc<T> {
         let id = map.next_id();
 
         let origin = Origin {
-            kind: OriginKind::New(id),
+            kind: OriginKind::New,
             site,
+            id,
         };
 
         map.strongs.insert(id, origin);
@@ -139,11 +140,12 @@ impl<T> Snarc<T> {
             .get(&self.id)
             .expect("Internal consistency error (clone). This should never happen.")
             .clone();
-        let new_origin = Origin {
-            kind: OriginKind::Cloned(self.id, Box::new(parent_origin)),
-            site,
-        };
         let new_id = map.next_id();
+        let new_origin = Origin {
+            kind: OriginKind::Cloned(Box::new(parent_origin)),
+            site,
+            id: new_id,
+        };
         map.strongs.insert(new_id, new_origin);
 
         Snarc {
@@ -164,11 +166,12 @@ impl<T> Snarc<T> {
             .get(&this.id)
             .expect("Internal consistency error (downgrade). This should never happen.")
             .clone();
-        let new_origin = Origin {
-            kind: OriginKind::Downgraded(this.id, Box::new(prev_origin)),
-            site,
-        };
         let new_id = map.next_id();
+        let new_origin = Origin {
+            kind: OriginKind::Downgraded(Box::new(prev_origin)),
+            site,
+            id: new_id,
+        };
         map.weaks.insert(new_id, new_origin);
 
         Weak {
@@ -309,11 +312,12 @@ impl<T> Weak<T> {
                     .get(&id)
                     .expect("Internal consistency error (upgrade)")
                     .clone();
-                let new_origin = Origin {
-                    kind: OriginKind::Upgraded(id, Box::new(prev_origin)),
-                    site,
-                };
                 let new_id = map.next_id();
+                let new_origin = Origin {
+                    kind: OriginKind::Upgraded(Box::new(prev_origin)),
+                    site,
+                    id: new_id,
+                };
                 map.strongs.insert(new_id, new_origin);
                 new_id
             };
@@ -347,11 +351,12 @@ impl<T> Weak<T> {
                     .get(&our_id)
                     .expect("Internal consistency error (weak clone). This should never happen.")
                     .clone();
-                let new_origin = Origin {
-                    kind: OriginKind::Cloned(our_id, Box::new(parent_origin)),
-                    site,
-                };
                 let new_id = map.next_id();
+                let new_origin = Origin {
+                    kind: OriginKind::Cloned(Box::new(parent_origin)),
+                    site,
+                    id: new_id,
+                };
                 map.weaks.insert(new_id, new_origin);
 
                 Weak {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,13 +109,14 @@ impl<T> Snarc<T> {
     ///
     /// Directly accepts a `Site` instance, creates the correct `Origin` with `OriginKind::New`.
     fn new_at_site(data: T, site: Site) -> Snarc<T> {
+        let mut map = Map::new();
+        let id = map.next_id();
+
         let origin = Origin {
-            kind: OriginKind::New,
+            kind: OriginKind::New(id),
             site,
         };
 
-        let mut map = Map::new();
-        let id = map.next_id();
         map.strongs.insert(id, origin);
 
         Snarc {

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -8,7 +8,7 @@ use std::fmt;
 pub type Uid = usize;
 
 /// Call site.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Ord, Eq)]
 pub enum Site {
     /// File/line location inside a source file.
     SourceFile {
@@ -36,7 +36,7 @@ impl fmt::Display for Site {
 }
 
 /// Reference origin.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Ord, Eq)]
 pub enum OriginKind {
     /// New object Instantiation (resulting ID),
     New,
@@ -51,15 +51,15 @@ pub enum OriginKind {
 }
 
 /// Describes origin and location of a new reference creation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Ord, Eq)]
 pub struct Origin {
+    /// The resulting ID of the instantiation.
+    pub id: Uid,
+    /// The site where the new instation occured.
+    pub site: Site,
     /// The kind of reference creation (new, via clone, downgrade, ...). In case there is a parent
     /// instance, its origin information will be contained in the `OriginKind` instance.
     pub kind: OriginKind,
-    /// The site where the new instation occured.
-    pub site: Site,
-    /// The resulting ID of the instantiation.
-    pub id: Uid,
 }
 
 impl fmt::Display for Origin {

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -20,14 +20,26 @@ pub enum Site {
     /// Used, when no information about the original call site was available at runtime.
     Unknown,
     // TODO: Backtrace,
-    // TODO: Annotation,
+    Annotated(String),
+}
+
+impl fmt::Display for Site {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Site::SourceFile { file, line } => write!(f, "{}:{}", file, line),
+            Site::Unknown => write!(f, "?"),
+            Site::Annotated(ref s) => write!(f, "\"{}\"", s),
+        }
+    }
 }
 
 /// Reference origin.
 #[derive(Debug, Clone)]
 pub enum OriginKind {
-    /// New object Instantiation.
-    New,
+    /// New object Instantiation (resulting ID),
+    New(Uid),
+    // FIXME: IDs need to be for current, not passed down.
+    // FIXME: Move ID into Origin.
     /// Cloned from another reference, (original ID, site of original reference).
     ClonedFrom(Uid, Box<Origin>),
     /// Upgraded from a weak reference, (weak reference ID, site of weak reference).

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -43,11 +43,11 @@ pub enum OriginKind {
     // FIXME: IDs need to be for current, not passed down.
     // FIXME: Move ID into Origin.
     /// Cloned from another reference, (original ID, site of original reference).
-    ClonedFrom(Uid, Box<Origin>),
+    Cloned(Uid, Box<Origin>),
     /// Upgraded from a weak reference, (weak reference ID, site of weak reference).
-    UpgradedFrom(Uid, Box<Origin>),
+    Upgraded(Uid, Box<Origin>),
     /// Downgraded from a strong reference, (strong reference ID, site of strong reference).
-    DowngradedFrom(Uid, Box<Origin>),
+    Downgraded(Uid, Box<Origin>),
 }
 
 /// Describes origin and location of a new reference creation.
@@ -70,15 +70,15 @@ impl fmt::Display for Origin {
                     write!(f, "new<{}>[{}]", id, link.site)?;
                     cur = None;
                 }
-                OriginKind::ClonedFrom(id, ref parent) => {
+                OriginKind::Cloned(id, ref parent) => {
                     write!(f, "clone<{}>[{}]", id, link.site)?;
                     cur = Some(parent);
                 }
-                OriginKind::UpgradedFrom(id, ref parent) => {
+                OriginKind::Upgraded(id, ref parent) => {
                     write!(f, "upgrade<{}>[{}]", id, link.site)?;
                     cur = Some(parent);
                 }
-                OriginKind::DowngradedFrom(id, ref parent) => {
+                OriginKind::Downgraded(id, ref parent) => {
                     write!(f, "downgrade<{}>[{}]", id, link.site)?;
                     cur = Some(parent);
                 }
@@ -135,17 +135,17 @@ mod tests {
         };
 
         let two = Origin {
-            kind: OriginKind::ClonedFrom(1, Box::new(one)),
+            kind: OriginKind::Cloned(1, Box::new(one)),
             site: Site::Annotated("step two".to_string()),
         };
 
         let three = Origin {
-            kind: OriginKind::DowngradedFrom(2, Box::new(two)),
+            kind: OriginKind::Downgraded(2, Box::new(two)),
             site: Site::Unknown,
         };
 
         let four = Origin {
-            kind: OriginKind::UpgradedFrom(3, Box::new(three)),
+            kind: OriginKind::Upgraded(3, Box::new(three)),
             site: Site::SourceFile {
                 file: "final.rs",
                 line: 42,


### PR DESCRIPTION
This complete the first technically useful version of the library, adding dumping capabilities and formatting. Example:

```rust
use snarc::{Dump, Snarc};

let foo = Snarc::new(123);
let bar = Snarc::clone_at_line(&foo, file!(), line!());
let weak = Snarc::downgrade(&bar);

println!("{}", Dump(&bar));
```

The result should be something like this:

```
Family associated with ID: 1
S| new<0>[?]
S| clone<1>[src/lib.rs:475] <- new<0>[?]
W| downgrade<2>[?] <- clone<1>[src/lib.rs:475] <- new<0>[?]
```

To make this happen, I had to change the `OriginKind` slightly; it no longer stores parent IDs. Instead, every `Origin` stores its own ID, which is much easier to work with.